### PR TITLE
Fix autostart reliability by using system Python path

### DIFF
--- a/virtualcam_app.py
+++ b/virtualcam_app.py
@@ -594,11 +594,12 @@ def install_autostart():
     desktop_entry = f"""[Desktop Entry]
 Type=Application
 Name=Elgato VirtualCam
-Exec={sys.executable} {os.path.abspath(__file__)}
+Exec=/usr/bin/python3 {os.path.abspath(__file__)}
 StartupNotify=false
 Terminal=false
 Hidden=false
 X-GNOME-Autostart-enabled=true
+X-GNOME-Autostart-Delay=10
 Comment=Elgato Facecam Virtual Camera Controller
 """
 


### PR DESCRIPTION
## Summary
- Fix autostart desktop entry to use system Python instead of mise-managed Python
- Add 10-second startup delay to ensure desktop environment is ready
- Improve reliability of virtual camera application startup after reboot

## Test plan
- [ ] Test manual application startup with system Python
- [ ] Test autostart installation with `--install-autostart` flag
- [ ] Verify autostart entry uses `/usr/bin/python3` path
- [ ] Confirm startup delay is included in desktop entry

## Changes
- Replace `sys.executable` with hardcoded `/usr/bin/python3` in autostart template
- Add `X-GNOME-Autostart-Delay=10` to desktop entry for better timing
- Ensures consistent behavior regardless of Python environment manager used